### PR TITLE
Fix Railway frontend deployment: Remove process.env references

### DIFF
--- a/frontend/src/utils/apiConfig.ts
+++ b/frontend/src/utils/apiConfig.ts
@@ -13,8 +13,7 @@ function isProduction(): boolean {
     import.meta.env.PROD === true ||
     import.meta.env.MODE === 'production' ||
     window.location.hostname.includes('railway.app') ||
-    window.location.hostname.includes('up.railway.app') ||
-    process.env.NODE_ENV === 'production'
+    window.location.hostname.includes('up.railway.app')
   );
 }
 
@@ -96,9 +95,9 @@ export function logApiConfig(): void {
       href: window.location.href,
       protocol: window.location.protocol
     },
-    // Node environment (if available)
+    // Node environment (not available in browser)
     node: {
-      nodeEnv: typeof process !== 'undefined' ? process.env?.NODE_ENV : 'undefined'
+      nodeEnv: 'browser-environment'
     },
     // Detection results
     detection: {


### PR DESCRIPTION
✅ RAILWAY BUILD FIXED:
- Removed process.env.NODE_ENV reference causing TS2580 error
- Fixed browser environment compatibility for Vite builds
- Maintained bulletproof environment detection without Node.js process

🔧 TECHNICAL CHANGES:
- Removed process.env.NODE_ENV from isProduction() function
- Simplified node environment detection for browser compatibility
- Preserved all multi-layer production environment detection

🚀 DEPLOYMENT READY:
- Frontend builds successfully without TypeScript errors
- API configuration still works perfectly in production
- Same-origin /api calls preserved for Railway deployment

This resolves the Railway buildkit error:
"Cannot find name 'process'. Do you need to install type definitions for node?"

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More reliable production detection in the browser for apps served from railway.app and up.railway.app domains.

- Bug Fixes
  - Removed reliance on server-side environment variables in the browser, preventing misclassification of environment status.

- Chores
  - Clarified browser debug logging: environment information now explicitly indicates a browser context rather than a Node.js context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->